### PR TITLE
[고도화] 리팩토링 - 테스트 코드 개선

### DIFF
--- a/src/test/java/com/board/projectboard/controller/AuthControllerTest.java
+++ b/src/test/java/com/board/projectboard/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -19,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("View 컨트롤러 - 인증")
 @Import(TestSecurityConfig.class)
-@WebMvcTest(Void.class)
+@WebMvcTest(AuthControllerTest.EmptyController.class)
 class AuthControllerTest {
     private final MockMvc mvc;
 
@@ -42,5 +43,11 @@ class AuthControllerTest {
         then(articleService).shouldHaveNoInteractions();
         then(paginationService).shouldHaveNoInteractions();
     }
+
+    /**
+     * 어떤 컨트롤러도 필요하지 않은 테스트임을 나타내기 위해 테스트용 빈 컴포넌트를 사용함.
+     */
+    @TestComponent
+    static class EmptyController {}
 
 }


### PR DESCRIPTION
원래 이 자리에는 아무 클래스가 아니라 빈이 들어가야 한다.
`Void`는 스프링 빈이 아니므로 정확한 표현이 아니고
일부 개발 환경에서 에러를 유발하는 것을 확인
이에 테스트 전용 빈을 제대로 만들어서 넣는 방법으로 개선.
테스트 빈은 아무 일도 하지 않는 것이 목적이기 때문에
안에 내용을 가지고 있지 않다.
다른 테스트에서 재활용할 가능성이 적은 점을 고려해
inner class 로 작성.