### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/board/projectboard/domain/Article.java
+++ b/src/main/java/com/board/projectboard/domain/Article.java
@@ -30,16 +30,22 @@ import java.util.Set;
 })
 @Entity
 public class Article extends BaseEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId")
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
     private UserAccount userAccount; // 유저 정보 (ID)
 
-    @Setter @Column(nullable = false)
+    @Setter
+    @Column(nullable = false)
     String title; // 제목
-    @Setter @Column(nullable = false, length = 65535)
+    @Setter
+    @Column(nullable = false, length = 65535)
     private String content; // 본문
+
     @Setter
     private String hashtag; // 해시태그
 

--- a/src/main/java/com/board/projectboard/domain/Article.java
+++ b/src/main/java/com/board/projectboard/domain/Article.java
@@ -71,12 +71,12 @@ public class Article extends BaseEntity {
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id); // id != null 코드를 추가함으로써 아직 영속화가 되지 않은 객체라면(=id를 부여받지 않은 상태)는 동등성 검사 탈락 처리
+        return this.getId() != null && this.getId().equals(article.getId()); // id != null 코드를 추가함으로써 아직 영속화가 되지 않은 객체라면(=id를 부여받지 않은 상태)는 동등성 검사 탈락 처리
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/board/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/board/projectboard/domain/ArticleComment.java
@@ -58,11 +58,11 @@ public class ArticleComment extends BaseEntity {
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/board/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/board/projectboard/domain/ArticleComment.java
@@ -24,16 +24,21 @@ import java.util.Objects;
 })
 @Entity
 public class ArticleComment extends BaseEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false)
+    @Setter
+    @ManyToOne(optional = false)
     private Article article; // 게시글 (ID)
 
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId")
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
     private UserAccount userAccount; // 유저 정보 (ID)
 
-    @Setter @Column(nullable = false, length = 2000)
+    @Setter
+    @Column(nullable = false, length = 2000)
     private String content; // 본문
 
     protected ArticleComment() {

--- a/src/main/java/com/board/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/board/projectboard/domain/UserAccount.java
@@ -57,11 +57,11 @@ public class UserAccount extends BaseEntity {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }

--- a/src/main/java/com/board/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/board/projectboard/domain/UserAccount.java
@@ -20,12 +20,22 @@ import java.util.Objects;
 })
 @Entity
 public class UserAccount extends BaseEntity {
+    @Id
+    @Column(length = 50)
+    private String userId;
 
-    @Id @Column(length = 50) private String userId;
-    @Setter @Column(nullable = false) private String userPassword;
+    @Setter
+    @Column(nullable = false)
+    private String userPassword;
 
-    @Setter @Column(length = 100) private String email;
-    @Setter @Column(length = 100) private String nickname;
+    @Setter
+    @Column(length = 100)
+    private String email;
+
+    @Setter
+    @Column(length = 100)
+    private String nickname;
+
     @Setter
     private String memo;
 


### PR DESCRIPTION
이 pr은 엔티티의 `equals()`, `hashcode()`가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #59 